### PR TITLE
Allow for different namespaces for nginx deployment vs secret

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-if [[ -z $EMAIL || -z $DOMAINS || -z $SECRET || -z $DEPLOYMENT ]]; then
-	echo "EMAIL, DOMAINS, SECERT, and DEPLOYMENT env vars required"
+if [[ -z $EMAIL || -z $DOMAINS || -z $SECRET || -z $DEPLOYMENT || -z $DEPLOYMENT_NAMESPACE ]]; then
+	echo "EMAIL, DOMAINS, SECERT, DEPLOYMENT, and DEPLOYMENT_NAMESPACE env vars required"
 	env
 	exit 1
 fi
 
-NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+CURRENT_NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 
 cd $HOME
 python -m SimpleHTTPServer 80 &
@@ -19,7 +19,7 @@ CERTPATH=/etc/letsencrypt/live/$(echo $DOMAINS | cut -f1 -d',')
 ls $CERTPATH || exit 1
 
 cat /secret-patch-template.json | \
-	sed "s/NAMESPACE/${NAMESPACE}/" | \
+	sed "s/NAMESPACE/${CURRENT_NAMESPACE}/" | \
 	sed "s/NAME/${SECRET}/" | \
 	sed "s/TLSCERT/$(cat ${CERTPATH}/fullchain.pem | base64 | tr -d '\n')/" | \
 	sed "s/TLSKEY/$(cat ${CERTPATH}/privkey.pem |  base64 | tr -d '\n')/" \
@@ -28,15 +28,15 @@ cat /secret-patch-template.json | \
 ls /secret-patch.json || exit 1
 
 # update secret
-curl -v --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k -v -XPATCH  -H "Accept: application/json, */*" -H "Content-Type: application/strategic-merge-patch+json" -d @/secret-patch.json https://kubernetes/api/v1/namespaces/${NAMESPACE}/secrets/${SECRET}
+curl -v --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k -v -XPATCH  -H "Accept: application/json, */*" -H "Content-Type: application/strategic-merge-patch+json" -d @/secret-patch.json https://kubernetes/api/v1/namespaces/${CURRENT_NAMESPACE}/secrets/${SECRET}
 
 cat /deployment-patch-template.json | \
 	sed "s/TLSUPDATED/$(date)/" | \
-	sed "s/NAMESPACE/${NAMESPACE}/" | \
+	sed "s/NAMESPACE/${DEPLOYMENT_NAMESPACE}/" | \
 	sed "s/NAME/${DEPLOYMENT}/" \
 	> /deployment-patch.json
 
 ls /deployment-patch.json || exit 1
 
 # update pod spec on ingress deployment to trigger redeploy
-curl -v --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k -v -XPATCH  -H "Accept: application/json, */*" -H "Content-Type: application/strategic-merge-patch+json" -d @/deployment-patch.json https://kubernetes/apis/extensions/v1beta1/namespaces/${NAMESPACE}/deployments/${DEPLOYMENT}
+curl -v --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k -v -XPATCH  -H "Accept: application/json, */*" -H "Content-Type: application/strategic-merge-patch+json" -d @/deployment-patch.json https://kubernetes/apis/extensions/v1beta1/namespaces/${DEPLOYMENT_NAMESPACE}/deployments/${DEPLOYMENT}


### PR DESCRIPTION
The official kubernetes nginx ingress controller deployments
recommend setting up the controller in a different namespace.