### PR TITLE
Allow configuring container against Let's Encrypt's staging environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN mkdir /etc/letsencrypt
 ENV DOMAINS= \
     EMAIL= \
     SECRET= \
-    DEPLOYMENT=
+    DEPLOYMENT= \
+    STAGING=
 
 CMD ["/entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ MAINTAINER Seth Jennings <sethdjennings@gmail.com>
 RUN dnf install certbot -y && dnf clean all
 RUN mkdir /etc/letsencrypt
 
+ENV DOMAINS= \
+    EMAIL= \
+    SECRET= \
+    DEPLOYMENT=
+
 CMD ["/entrypoint.sh"]
 
 COPY secret-patch-template.json /

--- a/build-push.sh
+++ b/build-push.sh
@@ -1,7 +1,12 @@
-#/bin/bash
+#/usr/bin/env bash
 
-docker build --tag sjenning/kube-nginx-letsencrypt:0.8.1-1 .
+set -e
+
+BASE=${1:-sjenning}
+VERSION=${2:-0.8.1-1}
+
+docker build --tag $BASE/kube-nginx-letsencrypt:$VERSION .
 echo "docker login before continuing"
 read
-docker push sjenning/kube-nginx-letsencrypt:0.8.1-1
+docker push $BASE/kube-nginx-letsencrypt:$VERSION
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,12 +6,14 @@ if [[ -z $EMAIL || -z $DOMAINS || -z $SECRET || -z $DEPLOYMENT ]]; then
 	exit 1
 fi
 
+CONFIGURATION="--webroot -w $HOME -n --agree-tos --email ${EMAIL} --no-self-upgrade -d ${DOMAINS}"
+
 NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 
 cd $HOME
 python -m SimpleHTTPServer 80 &
 PID=$!
-certbot certonly --webroot -w $HOME -n --agree-tos --email ${EMAIL} --no-self-upgrade -d ${DOMAINS}
+certbot certonly $CONFIGURATION
 kill $PID
 
 CERTPATH=/etc/letsencrypt/live/$(echo $DOMAINS | cut -f1 -d',')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,9 @@ if [[ -z $EMAIL || -z $DOMAINS || -z $SECRET || -z $DEPLOYMENT ]]; then
 fi
 
 CONFIGURATION="--webroot -w $HOME -n --agree-tos --email ${EMAIL} --no-self-upgrade -d ${DOMAINS}"
+if [[ -n $STAGING ]]; then
+  CONFIGURATION="--staging $CONFIGURATION"
+fi
 
 NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,25 +25,39 @@ CERTPATH=/etc/letsencrypt/live/$(echo $DOMAINS | cut -f1 -d',')
 
 ls $CERTPATH || exit 1
 
+
+echo "Update secret..."
 cat /secret-patch-template.json | \
 	sed "s/NAMESPACE/${NAMESPACE}/" | \
 	sed "s/NAME/${SECRET}/" | \
 	sed "s/TLSCERT/$(cat ${CERTPATH}/fullchain.pem | base64 | tr -d '\n')/" | \
 	sed "s/TLSKEY/$(cat ${CERTPATH}/privkey.pem |  base64 | tr -d '\n')/" \
 	> /secret-patch.json
-
 ls /secret-patch.json || exit 1
 
-# update secret
-curl -v --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k -v -XPATCH  -H "Accept: application/json, */*" -H "Content-Type: application/strategic-merge-patch+json" -d @/secret-patch.json https://kubernetes/api/v1/namespaces/${NAMESPACE}/secrets/${SECRET}
+curl -v --fail \
+  -k --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+  -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -H "Accept: application/json, */*" \
+  -H "Content-Type: application/strategic-merge-patch+json" \
+  -X PATCH \
+  -d @/secret-patch.json \
+  https://kubernetes/api/v1/namespaces/${NAMESPACE}/secrets/${SECRET}
 
+
+echo "Update the pod spec on ingress deployment to trigger redeploy..."
 cat /deployment-patch-template.json | \
 	sed "s/TLSUPDATED/$(date)/" | \
 	sed "s/NAMESPACE/${NAMESPACE}/" | \
 	sed "s/NAME/${DEPLOYMENT}/" \
 	> /deployment-patch.json
-
 ls /deployment-patch.json || exit 1
 
-# update pod spec on ingress deployment to trigger redeploy
-curl -v --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" -k -v -XPATCH  -H "Accept: application/json, */*" -H "Content-Type: application/strategic-merge-patch+json" -d @/deployment-patch.json https://kubernetes/apis/extensions/v1beta1/namespaces/${NAMESPACE}/deployments/${DEPLOYMENT}
+curl --fail \
+  -k --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+  -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+  -H "Accept: application/json, */*" \
+  -H "Content-Type: application/strategic-merge-patch+json" \
+  -X PATCH  \
+  -d @/deployment-patch.json \
+  https://kubernetes/apis/extensions/v1beta1/namespaces/${NAMESPACE}/deployments/${DEPLOYMENT}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [[ -z $EMAIL || -z $DOMAINS || -z $SECRET || -z $DEPLOYMENT ]]; then
 	echo "EMAIL, DOMAINS, SECERT, and DEPLOYMENT env vars required"
 	env


### PR DESCRIPTION
Testing a container deployment on Let's Encrypt's production servers can hit the rate limits quickly. This commit allows to test against the [staging environment](https://letsencrypt.org/docs/staging-environment/).

Also, the Dockerfile now accepts environment variables, also convenient for testing. Usage:

    docker run -e STAGING=true \
               -e DOMAINS=my.secured.com \
               -e EMAIL=my.email@example.com \
               -e SECRET=letsencrypt-certs \
               -e DEPLOYMENT=letsencrypt \
               -p 80:80 \
               epic/kube-nginx-letsencrypt:latest

The environment variables default to the original values in the original script.